### PR TITLE
Minor Bug in scrambledWriter() 

### DIFF
--- a/javascripts/jquery.text-effects.js
+++ b/javascripts/jquery.text-effects.js
@@ -36,7 +36,7 @@
                 random = randomAlphaNum, inc = 3;
             $ele.text('');
             var timer = setInterval(function() {
-                $ele.text(str.substring(0, progress) + str.substring(progress, str.length - 1).replace(replace, random));
+                $ele.text(str.substring(0, progress) + str.substring(progress, str.length).replace(replace, random));
                 progress += inc
                 if (progress >= str.length + inc) clearInterval(timer);
             }, 100);


### PR DESCRIPTION
There's a minor bug in the scrambledWriter() function - EXTRA random alpha-numeric characters are added to the end of the string.
## Steps to reproduce:
- Look at the lorem ipsum demo @ text-effects.html.
- Scroll down to the Scrambled Writer section.
- Click on 'Run demo'
- Once it's finished, the text will end "id est laborum.X", where X is a random alpha-numeric character. 
- If you click 'Run demo' again you'll see more characters being added "id est laborum.XX", "id est laborum.XXX", etc.

See attached fix.

Cheers,
  Lee
