### PR TITLE
shadow does not get built until the the textarea has been rendered. This 

### DIFF
--- a/javascripts/jquery.autogrow-textarea.js
+++ b/javascripts/jquery.autogrow-textarea.js
@@ -1,3 +1,4 @@
+
 (function($) {
 
     /*
@@ -6,24 +7,35 @@
     $.fn.autogrow = function(options) {
         
         this.filter('textarea').each(function() {
-            
             var $this       = $(this),
-                minHeight   = $this.height(),
-                lineHeight  = $this.css('lineHeight');
+                minHeight   = -1,
+                lineHeight  = '';
             
-            var shadow = $('<div></div>').css({
-                position:   'absolute',
-                top:        -10000,
-                left:       -10000,
-                width:      $(this).width() - parseInt($this.css('paddingLeft')) - parseInt($this.css('paddingRight')),
-                fontSize:   $this.css('fontSize'),
-                fontFamily: $this.css('fontFamily'),
-                lineHeight: $this.css('lineHeight'),
-                resize:     'none'
-            }).appendTo(document.body);
-            
+            var shadow = undefined;
+
             var update = function() {
-    
+                //only set the shadow if it has not been set already and this is
+                //the first time that update has been called with $this having a 
+                //height of > 0
+                if(shadow === undefined && $this.height() !== 0){
+                    minHeight   = $this.height(),
+                    lineHeight  = $this.css('lineHeight');
+                    shadow = $('<div></div>').css({
+                        position:   'absolute',
+                        top:        -10000,
+                        left:       -10000,
+                        width:      $(this).width() - parseInt($this.css('paddingLeft')) - parseInt($this.css('paddingRight')),
+                        fontSize:   $this.css('fontSize'),
+                        fontFamily: $this.css('fontFamily'),
+                        lineHeight: $this.css('lineHeight'),
+                        resize:     'none'
+                    }).appendTo(document.body);
+                }
+                //If we do not have a shadow yet, it is because $this does not have
+                //a height or width. Do nothing.
+                if(shadow === undefined){
+                    return;
+                }
                 var times = function(string, number) {
                     for (var i = 0, r = ''; i < number; i ++) r += string;
                     return r;
@@ -40,11 +52,8 @@
                 $(this).css('height', Math.max(shadow.height() + 20, minHeight));
             
             }
-            
             $(this).change(update).keyup(update).keydown(update);
-            
             update.apply(this);
-            
         });
         
         return this;


### PR DESCRIPTION
shadow does not get built until the the textarea has been rendered. This change is not very heavily tested.

it fixed a bug where if autogrow() was called before the text area had been rendered, the first call to update() set the height of the textarea to 0.
