### PR TITLE
Fixed some niggling problems.

### DIFF
--- a/javascripts/jquery.autogrow-textarea.js
+++ b/javascripts/jquery.autogrow-textarea.js
@@ -9,24 +9,25 @@
     {
         return this.filter('textarea').each(function()
         {
-            var self                                = this;
-            var $self                               = $(self);
-            var minHeight                           = $self.height();
-            var noFlickerPad                        = $self.hasClass('autogrow-short') ? 0 : parseInt($self.css('lineHeight'));
+            var self         = this;
+            var $self        = $(self);
+            var minHeight    = $self.height();
+            var noFlickerPad = $self.hasClass('autogrow-short') ? 0 : parseInt($self.css('lineHeight')) || 0;
 
             var shadow = $('<div></div>').css({
-                position:   'absolute',
-                top:        -10000,
-                left:       -10000,
-                width:      $self.width(),
-                fontSize:   $self.css('fontSize'),
-                fontFamily: $self.css('fontFamily'),
-                fontWeight: $self.css('fontWeight'),
-                lineHeight: $self.css('lineHeight'),
-                resize:     'none'
+                position:    'absolute',
+                top:         -10000,
+                left:        -10000,
+                width:       $self.width(),
+                fontSize:    $self.css('fontSize'),
+                fontFamily:  $self.css('fontFamily'),
+                fontWeight:  $self.css('fontWeight'),
+                lineHeight:  $self.css('lineHeight'),
+                resize:      'none',
+    			'word-wrap': 'break-word'
             }).appendTo(document.body);
 
-            var update = function()
+            var update = function(event)
             {
                 var times = function(string, number)
                 {
@@ -41,12 +42,17 @@
                                     .replace(/\n/g, '<br/>')
                                     .replace(/ {2,}/g, function(space){ return times('&nbsp;', space.length - 1) + ' ' });
 
+				// Did enter get pressed?  Resize in this keydown event so that the flicker doesn't occur.
+				if (event && event.data && event.data.event === 'keydown' && event.keyCode === 13) {
+					val += '<br />';
+				}
+
                 shadow.css('width', $self.width());
-                shadow.html(val);
-                $self.css('height', Math.max(shadow.height() + noFlickerPad, minHeight));
+                shadow.html(val + (noFlickerPad === 0 ? '...' : '')); // Append '...' to resize pre-emptively.
+                $self.height(Math.max(shadow.height() + noFlickerPad, minHeight));
             }
 
-            $self.change(update).keyup(update).keydown(update);
+            $self.change(update).keyup(update).keydown({event:'keydown'},update);
             $(window).resize(update);
 
             update();


### PR DESCRIPTION
- Handled case where textarea has no line-height.
- Added 'word-wrap' style to shadow textarea; height calculation for long lines of text with no spaces behaves better.
- Added detection for enter character in keydown event which inserts a '&lt;br /&gt;' to the shadow html.  This means no more flicker on enter key presses.
- Added a '...' to the end of shadow when noFlickerPad is zero; this causes an extra line to appear when getting close to causing a wrap.  No more flicker on text wrap.
