### PR TITLE
Update jquery.input-hint.js

### DIFF
--- a/javascripts/jquery.input-hint.js
+++ b/javascripts/jquery.input-hint.js
@@ -24,10 +24,14 @@
    */
   $.fn.inputHint = function(options) {
     
-    var i = document.createElement('input');
-    if ('placeholder' in i) return this;
-    
     options = $.extend({hintClass: 'hint', hintAttr: 'placeholder'}, options || {});
+    
+    if (options.hintAttr == 'placeholder') {
+      var i = document.createElement('input');
+      if ('placeholder' in i) return this;
+    }
+    
+    
     
     function hintFor(element) {
       var h;


### PR DESCRIPTION
Only check for native placeholder support if we're actually using 'placeholder' for hint value.
Was unable to use 'title' attribute on Chrome as it supports 'placeholder' and promptly exited the plugin.
