### PR TITLE
Fixed typewriter() last character not printing bug.

### DIFF
--- a/javascripts/jquery.text-effects.js
+++ b/javascripts/jquery.text-effects.js
@@ -49,7 +49,7 @@
             var $ele = $(this), str = $ele.text(), progress = 0;
             $ele.text('');
             var timer = setInterval(function() {
-                $ele.text(str.substring(0, progress++) + (progress & 1 ? '_' : ''));
+                $ele.text(str.substring(0, ++progress) + (progress & 1 ? '_' : ''));
                 if (progress >= str.length) clearInterval(timer);
             }, 100);
         });


### PR DESCRIPTION
Currently if typewriter() is used on '0123456789', it will only type '012345678' out.

According to MDN, '++' If used postfix, with operator after operand (for example, x++), then it returns the value before incrementing. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment_())

Using prefix instead so it will substring with correct index and keep the last character.
